### PR TITLE
Bump to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A Video.js Tech plugin for Ogv.js",
   "author": "Derk-Jan Hartman",
   "license": "(MIT OR Apache-2.0)",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "es5/plugin.js",
   "keywords": [
     "videojs",


### PR DESCRIPTION
Reason I'm bumping to 1.2.0 and not 1.1.2 is because it includes a slightly big update to ogv.js
