### PR TITLE
Update ogv.js to alpha 2 and update videojs to 5.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
     "watch:test": "watchify `find test -name '*.test.js'` -t babelify -o dist-test/videojs-ogvjs.js"
   },
   "dependencies": {
-    "ogv": "^1.1.0-alpha.0",
-    "video.js": "^5.8.8"
+    "ogv": "^1.1.0-alpha.2",
+    "video.js": "^5.10.1"
   },
   "devDependencies": {
     "babel": "^5.8.0",


### PR DESCRIPTION
videojs 5.10.1 includes the src fix that allows us to change resolutions now.

Patch in timedmediahandler https://gerrit.wikimedia.org/r/#/c/284375/
